### PR TITLE
Update favicon

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: Calva Documentation
 theme:
   name: material
   custom_dir: theming/
+  favicon: img/favicon.ico
 extra_css:
   - stylesheets/extra.css
 site_url: https://calva.io


### PR DESCRIPTION
This PR replaces the MkDocs favicon with Calva's.

The MkDocs Material Theme has its own [instructions](https://squidfunk.github.io/mkdocs-material/getting-started/#favicon) for changing the favicon.